### PR TITLE
add a prefix for script src attributes when loaded on partners.stage.…

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,5 +1,6 @@
 <!-- Modifying this file will impact your performance -->
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+<--! TODO: evaluate if we can serve /scripts directly from Akamai -->
 <script>
   let scriptSrc = "/scripts/scripts.js";
   let fallbackScriptSrc = "/scripts/scripts.js";

--- a/head.html
+++ b/head.html
@@ -1,6 +1,6 @@
 <!-- Modifying this file will impact your performance -->
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<--! TODO: evaluate if we can serve /scripts directly from Akamai -->
+<!-- TODO: evaluate if we can serve /scripts directly from Akamai -->
 <script>
   let scriptSrc = "/scripts/scripts.js";
   let fallbackScriptSrc = "/scripts/scripts.js";

--- a/head.html
+++ b/head.html
@@ -1,6 +1,20 @@
 <!-- Modifying this file will impact your performance -->
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<script src="/scripts/fallback.js" nomodule></script>
-<script src="/scripts/scripts.js" type="module"></script>
+<script>
+  let scriptSrc = "/scripts/scripts.js";
+  let fallbackScriptSrc = "/scripts/scripts.js";
+  if (window.location.hostname === "partners.stage.adobe.com") {
+    scriptSrc = "/technologypartners/scripts/scripts.js";
+    fallbackScriptSrc = "/technologypartners/scripts/scripts.js";
+  }
+  let fallbackScript = document.createElement('script');
+  fallbackScript.src = fallbackScriptSrc;
+  fallbackScript.setAttribute("nomodule", true);
+  document.head.append(fallbackScript);
+  let script = document.createElement('script');
+  script.src = scriptSrc
+  script.setAttribute("type", "module");
+  document.head.append(script);
+</script>
 <style>body { display: none; }</style>
 <link rel="icon" href="data:,">


### PR DESCRIPTION
…adobe.com.

This prefix will trigger the edgeworkers, it can be revode on the edworker onClientRequest

URL for testing:

- https://add-script-prefix-for-stage--dx-partners--adobecom.hlx.page/technologypartners/drafts/ben/public-document