### PR TITLE
replaced empty space with dash for bad authored keys

### DIFF
--- a/eds/blocks/knowledge-base-overview/knowledge-base-overview.js
+++ b/eds/blocks/knowledge-base-overview/knowledge-base-overview.js
@@ -57,7 +57,7 @@ export default async function init(el) {
     },
     'filter': (cols) => {
       const [filterKeyEl, filterValueEl, filterTagsKeysEl, filterTagsValueEl] = cols;
-      const filterKey = filterKeyEl.innerText.trim().toLowerCase();
+      const filterKey = filterKeyEl.innerText.trim().toLowerCase().replaceAll(' ', '-');
       const filterValue = filterValueEl.innerText.trim();
       const filterTagsKeys = Array.from(filterTagsKeysEl.querySelectorAll('li'), (li) => li.innerText.trim().toLowerCase());
       const filterTagsValue = Array.from(filterTagsValueEl.querySelectorAll('li'), (li) => li.innerText.trim());

--- a/eds/blocks/partner-news/partner-news.js
+++ b/eds/blocks/partner-news/partner-news.js
@@ -58,7 +58,7 @@ export default async function init(el) {
     },
     'filter': (cols) => {
       const [filterKeyEl, filterValueEl, filterTagsKeysEl, filterTagsValueEl] = cols;
-      const filterKey = filterKeyEl.innerText.trim().toLowerCase();
+      const filterKey = filterKeyEl.innerText.trim().toLowerCase().replaceAll(' ', '-');
       const filterValue = filterValueEl.innerText.trim();
       const filterTagsKeys = Array.from(filterTagsKeysEl.querySelectorAll('li'), (li) => li.innerText.trim().toLowerCase());
       const filterTagsValue = Array.from(filterTagsValueEl.querySelectorAll('li'), (li) => li.innerText.trim());

--- a/eds/components/PartnerCards.js
+++ b/eds/components/PartnerCards.js
@@ -386,8 +386,10 @@ export class PartnerCards extends LitElement {
 
         return selectedFiltersKeys.every((key) =>
           cardArbitraryArr.some((arbitraryTag) => {
-            if (key === arbitraryTag.key.toLowerCase()) {
-              return this.selectedFilters[key].some((selectedTag) => selectedTag.key === arbitraryTag.value.toLowerCase());
+            const arbitraryTagKeyStr = arbitraryTag.key.trim().toLowerCase().replaceAll(' ', '-');
+            const arbitraryTagValueStr = arbitraryTag.value.trim().toLowerCase().replaceAll(' ', '-');
+            if (key === arbitraryTagKeyStr) {
+              return this.selectedFilters[key].some((selectedTag) => selectedTag.key === arbitraryTagValueStr);
             }
             return false;
           })


### PR DESCRIPTION
Removed empty spaces before/after keys and replaced empty space between words with dash if authoring is not correct 

LInks:
The card with not correct authored arbitrary 'Region:Asia Pacific' https://main--dx-partners--adobecom.hlx.live/solutionpartners/drafts/automation/regression/caas-cards/automation-regression-card-no6 will now be displayed among cards if filter is applied

Before: 
- https://stage--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/partner-news?filters=yes&region=asia-pacific
- https://stage--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/knowledge-overview?filters=yes&region=asia-pacific

After: 
- https://filters-key-fix--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/partner-news?filters=yes&region=asia-pacific
- https://filters-key-fix--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/knowledge-overview?filters=yes&region=asia-pacific


NOTE:
This fix is resolved in pr: https://github.com/adobecom/dx-partners/pull/13
I will close the ticket