### PR TITLE
MWPW-151994 filter labels width

### DIFF
--- a/eds/components/PartnerCardsStyles.js
+++ b/eds/components/PartnerCardsStyles.js
@@ -152,9 +152,10 @@ export var partnerCardsStyles = css`
     width: 100%;
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
     color: #464646;
     transition: color .3s ease-in-out;
+    padding: 12px 5px 14px;
   }
   
   .partner-cards-sidebar .filter .filter-header:hover {
@@ -166,7 +167,8 @@ export var partnerCardsStyles = css`
     font-size: .875rem;
     line-height: 1rem;
     font-weight: 700;
-    padding: 14px 0;
+    text-align: left;
+    max-width: 122px;
   }
   
   .partner-cards-sidebar .filter .filter-chevron-icon {
@@ -175,12 +177,13 @@ export var partnerCardsStyles = css`
     display: inline-block;
     padding: 3px;
     transform: rotate(45deg);
+    margin-top: 2px;
   }
   
   .partner-cards-sidebar .filter .filter-selected-tags-count-btn {
     position: absolute;
-    top: 10px;
-    right: 25px;
+    top: 8px;
+    right: 18px;
     border: none;
     background-color: ${blueColor};
     min-width: 24px;

--- a/eds/components/PartnerCardsStyles.js
+++ b/eds/components/PartnerCardsStyles.js
@@ -242,6 +242,7 @@ export var partnerCardsStyles = css`
     font-size: .875rem;
     line-height: 1rem;
     width: 100%;
+    overflow-wrap: anywhere;
   }
   
   .partner-cards-sidebar .filter-list li:hover {
@@ -821,6 +822,7 @@ export var partnerCardsStyles = css`
   
   .filter-wrapper-mobile.expanded .filter-tags-mobile sp-checkbox {
     width: 100%;
+    overflow-wrap: anywhere;
   }
   
   .filter-wrapper-mobile .filter-footer-mobile-wrapper {


### PR DESCRIPTION
**Resolves:** https://jira.corp.adobe.com/browse/MWPW-151994

- fixed the width of the filter label for very long words
- for checkboxes with very long words, word-break is applied (desktop and mobile)
- dropdown arrow is always on the top
- fixed the alignment for the whole filter dropdown


**Links:**

**Before:** https://stage--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/partner-news
**After:** https://mwpw-151994-filter-labels-width--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/partner-news