### PR TITLE
MWPW-151916-collectionTags moved to complexQuery params

### DIFF
--- a/eds/blocks/knowledge-base-overview/knowledge-base-overview.js
+++ b/eds/blocks/knowledge-base-overview/knowledge-base-overview.js
@@ -56,7 +56,7 @@ export default async function init(el) {
     'tableData' : el.children,
     'cardsPerPage': 9,
     'ietf': config.locale.ietf,
-    'collectionTags': 'caas:adobe-partners/collections/knowledge-base'
+    'collectionTags': '"caas:adobe-partners/collections/knowledge-base"'
   }
 
   const app = document.createElement('knowledge-base-overview');

--- a/eds/blocks/partner-news/partner-news.js
+++ b/eds/blocks/partner-news/partner-news.js
@@ -69,7 +69,7 @@ export default async function init(el) {
     'dateFilter': dateFilter,
     'cardsPerPage': 12,
     'ietf': config.locale.ietf,
-    'collectionTags': 'caas:adobe-partners/collections/news'
+    'collectionTags': '"caas:adobe-partners/collections/news"'
   }
 
   const app = document.createElement('partner-news');

--- a/eds/components/PartnerCards.js
+++ b/eds/components/PartnerCards.js
@@ -197,7 +197,7 @@ export class PartnerCards extends LitElement {
 
   async fetchData() {
     try {
-      const api = new URL('https://14257-chimera.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection?originSelection=dx-partners&draft=false&debug=true&flatFile=false&expanded=true');
+      const api = new URL('https://www.adobe.com/chimera-api/collection?originSelection=dx-partners&draft=false&debug=true&flatFile=false&expanded=true');
       const apiWithParams = this.setApiParams(api);
       const response = await fetch(apiWithParams);
       if (!response.ok) {

--- a/eds/components/PartnerCards.js
+++ b/eds/components/PartnerCards.js
@@ -164,7 +164,7 @@ export class PartnerCards extends LitElement {
       },
       'collection-tags': (cols) => {
         const [collectionTagsEl] = cols;
-        const collectionTags = Array.from(collectionTagsEl.querySelectorAll('li'), (li) => li.innerText.trim().toLowerCase());
+        const collectionTags = Array.from(collectionTagsEl.querySelectorAll('li'), (li) => '"' + li.innerText.trim().toLowerCase() + '"');
         this.collectionTags = [...this.collectionTags, ...collectionTags];
       }
     }
@@ -221,22 +221,8 @@ export class PartnerCards extends LitElement {
   }
 
   setApiParams(api) {
-    const portal = this.getProgramType(window.location.pathname);
-
-    if (portal) {
-      const portalCollectionTag = `caas:adobe-partners/${portal}`;
-      if (!this.collectionTags.length || !this.collectionTags.includes(portalCollectionTag)) {
-        this.collectionTags = [...this.collectionTags, portalCollectionTag];
-      }
-
-      const partnerDataComplexQueryParam = this.getPartnerDataComplexQueryParam(portal);
-      if (partnerDataComplexQueryParam) api.searchParams.set('complexQuery', partnerDataComplexQueryParam);
-    }
-
-    if(this.collectionTags.length) {
-      const collectionTagsStr = this.collectionTags.filter(e => e.length).join(',');
-      api.searchParams.set('collectionTags', collectionTagsStr);
-    }
+    const complexQueryParams = this.getComplexQueryParams();
+    if (complexQueryParams) api.searchParams.set('complexQuery', complexQueryParams);
 
     const { language, country } = this.blockData;
     if (language && country) {
@@ -247,7 +233,26 @@ export class PartnerCards extends LitElement {
     return api.toString();
   }
 
-  getPartnerDataComplexQueryParam (portal) {
+  getComplexQueryParams() {
+    const portal = this.getProgramType(window.location.pathname);
+    let partnerLevelParams;
+
+    if (portal) {
+      const portalCollectionTag = `"caas:adobe-partners/${portal}"`;
+      if (!this.collectionTags.length || !this.collectionTags.includes(portalCollectionTag)) {
+        this.collectionTags = [...this.collectionTags, portalCollectionTag];
+      }
+
+      partnerLevelParams = this.getPartnerLevelParams(portal);
+    }
+
+    if (!this.collectionTags.length) return;
+
+    const collectionTagsStr = this.collectionTags.filter(e => e.length).join('+AND+');
+    return partnerLevelParams ? `((${collectionTagsStr}))+AND+${partnerLevelParams}` : `((${collectionTagsStr}))`;
+  }
+
+  getPartnerLevelParams(portal) {
     try {
       const publicTag = `(("caas:adobe-partners/${portal}/partner-level/public"))`;
       const cookies = document.cookie.split(';').map(cookie => cookie.trim());


### PR DESCRIPTION
Resolves: https://jira.corp.adobe.com/browse/MWPW-151916

NOTE: collectionTags are not longer sent to the API; instead, complexQuery should be sent with: 
- component specific tag
- portal specific tag (if a portal exists)
- authored tags (if they are authored)
- partner level tag (if a portal exists); a public tag will be sent for both logged-in and not logged-in users

LINKS:
Before: 
https://stage--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/partner-news-collection-tags

After:
https://mwpw-151916-complexquery-params--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/partner-news-collection-tags


