### PR TITLE
MWPW-152074 - news component: future cards included for 'show all' date filter

### DIFF
--- a/eds/blocks/partner-news/PartnerNews.js
+++ b/eds/blocks/partner-news/PartnerNews.js
@@ -23,15 +23,14 @@ export class PartnerNews extends PartnerCards {
   }
 
   additionalFirstUpdated() {
-    const currentDate = new Date();
-    currentDate.setHours(0, 0, 0, 0);
-    const startDate = new Date(currentDate);
+    const startDate = new Date();
+    startDate.setHours(0, 0, 0, 0);
     startDate.setDate(startDate.getDate() - 180);
 
     this.allCards =  this.allCards.filter(card => {
       const cardDate = new Date(card.cardDate);
 
-      if (cardDate >= startDate && cardDate <= currentDate) return true;
+      if (cardDate >= startDate) return true;
 
       const isNeverExpires = card.tags.some((tag) => tag.id === "caas:adobe-partners/collections/news/never-expires");
       return isNeverExpires;


### PR DESCRIPTION
Additional PR for resolving: [MWPW-152074](https://jira.corp.adobe.com/browse/MWPW-152074)

**LINKS:**

**Before:** https://stage--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/partner-news
**After:** https://mwpw-152074-display-future-cards--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/partner-news

**NOTE:** 
For the 'show all' option in the date filter, cards with future dates are now displayed.