### PR TITLE
MWPW-153919 - removed partner news archive; removed date limitation;

### DIFF
--- a/eds/blocks/partner-news/PartnerNews.js
+++ b/eds/blocks/partner-news/PartnerNews.js
@@ -22,28 +22,6 @@ export class PartnerNews extends PartnerCards {
     this.selectedDateFilter = {};
   }
 
-  additionalFirstUpdated() {
-    const startDate = new Date();
-    startDate.setHours(0, 0, 0, 0);
-    startDate.setDate(startDate.getDate() - 180);
-
-    this.allCards = this.allCards.filter((card) => {
-      const isNeverExpires = card.tags.some((tag) => tag.id === 'caas:adobe-partners/collections/news/never-expires');
-      const cardDate = new Date(card.cardDate);
-
-      if (this.blockData.isArchive) {
-        if (isNeverExpires) return false;
-        return cardDate <= startDate;
-      }
-      return cardDate > startDate || isNeverExpires;
-    });
-
-    if (this.blockData.dateFilter) {
-      const [firstDateFilter] = this.blockData.dateFilter.tags;
-      this.selectedDateFilter = firstDateFilter;
-    }
-  }
-
   get pagination() {
     if (this.cards.length === this.paginatedCards.length) {
       return ''

--- a/eds/blocks/partner-news/partner-news.js
+++ b/eds/blocks/partner-news/partner-news.js
@@ -19,7 +19,6 @@ export default async function init(el) {
   const miloLibs = getLibs();
   const config = getConfig();
 
-  const isArchive = el.classList.contains('archive');
   const sectionIndex = el.parentNode.getAttribute('data-idx');
 
   let localizedText = {
@@ -58,12 +57,12 @@ export default async function init(el) {
   const dateFilter = {
     key: 'date',
     value: localizedText['{{date}}'],
-    tags: isArchive
-      ? [{ key: 'show-all', value: localizedText['{{show-all}}'], parentKey: 'date', checked: true, default: true }]
-      : [{ key: 'show-all', value: localizedText['{{show-all}}'], parentKey: 'date', checked: true, default: true },
-        { key: 'current-month', value: localizedText['{{current-month}}'], parentKey: 'date', checked: false },
-        { key: 'previous-month', value: localizedText['{{previous-month}}'], parentKey: 'date', checked: false },
-        { key: 'last-90-days', value: localizedText['{{last-90-days}}'], parentKey: 'date', checked: false }],
+    tags: [
+      { key: 'show-all', value: localizedText['{{show-all}}'], parentKey: 'date', checked: true, default: true },
+      { key: 'current-month', value: localizedText['{{current-month}}'], parentKey: 'date', checked: false },
+      { key: 'previous-month', value: localizedText['{{previous-month}}'], parentKey: 'date', checked: false },
+      { key: 'last-90-days', value: localizedText['{{last-90-days}}'], parentKey: 'date', checked: false },
+    ],
   };
 
   const blockData = {
@@ -73,7 +72,6 @@ export default async function init(el) {
     'cardsPerPage': 12,
     'ietf': config.locale.ietf,
     'collectionTags': '"caas:adobe-partners/collections/news"',
-    isArchive,
   }
 
   const app = document.createElement('partner-news');

--- a/eds/components/PartnerCards.js
+++ b/eds/components/PartnerCards.js
@@ -191,11 +191,8 @@ export class PartnerCards extends LitElement {
     if (this.blockData.filters.length) this.initUrlSearchParams();
     if (this.blockData.sort.items.length) this.selectedSortOrder = this.blockData.sort.default;
     if (this.blockData.cardsPerPage) this.cardsPerPage = this.blockData.cardsPerPage;
-    this.additionalFirstUpdated();
     this.handleActions();
   }
-
-  additionalFirstUpdated() {}
 
   async fetchData() {
     try {


### PR DESCRIPTION
Resolves: [MWPW-153919](https://jira.corp.adobe.com/browse/MWPW-153919)

- removed the Partner news archive block
- displayed all the cards and removed the limitation for cards older than 180 days
- updated the library and kitchen-sink

LINKS:
Before: https://stage--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/partner-news
After: https://mwpw-153919-removed-news-archive--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/partner-news

NOTE:
- date picker will be implemented in [MWPW-153655](https://jira.corp.adobe.com/browse/MWPW-153655)