### PR TITLE
MWPW-155065 PartnerCards fallback for invalid thumbnail images

### DIFF
--- a/eds/components/NewsCard.js
+++ b/eds/components/NewsCard.js
@@ -4,6 +4,9 @@ import { formatDate, getLibs } from '../scripts/utils.js';
 const miloLibs = getLibs();
 const { html, LitElement } = await import(`${miloLibs}/deps/lit-all.min.js`);
 
+// @todo - make this configurable somewhere.
+const DEFAULT_BACKGROUND_IMAGE_URL = 'https://solutionpartners.stage2.adobe.com/content/dam/solution/en/images/card-collection/sample_default.png';
+
 class NewsCard extends LitElement {
   static properties = { data: { type: Object } };
 
@@ -21,6 +24,22 @@ class NewsCard extends LitElement {
     newUrl.protocol = window.location.protocol;
     newUrl.host = window.location.host;
     return newUrl;
+  }
+
+  checkBackgroundImage(element) {
+    const style = window.getComputedStyle(element);
+    const url = style.backgroundImage.slice(5, -2);
+    const img = new Image();
+
+    img.onerror = () => {
+      element.style.backgroundImage = `url(${DEFAULT_BACKGROUND_IMAGE_URL})`;
+    };
+
+    img.src = url;
+  }
+
+  firstUpdated() {
+    this.checkBackgroundImage(this.shadowRoot.querySelector('.card-header'));
   }
 
   render() {

--- a/eds/components/PartnerCardsStyles.js
+++ b/eds/components/PartnerCardsStyles.js
@@ -922,7 +922,7 @@ export const newsCardStyles = css`
   .news-card .card-header {
     min-height: 192px;
     max-height: 192px;
-    background-color: #323232;
+    background-color: #f5f5F5;
     background-repeat: no-repeat;
     background-position: 50% 50%;
     background-size: cover;


### PR DESCRIPTION
- checks news card background image on first updated
- replace with a hardcoded default (needs configuration somewhere)
- changes the background color of the card header to prevent FOUC

**LINKS:**

**Before:**
- https://stage--dx-partners--adobecom.hlx.page/technologypartners/drafts/dragana/knowledge-overview
- https://stage--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/partner-news

**After:**
- https://mwpw-155065-partner-cards-fallback-for-invalid-thumbnail-images--dx-partners--adobecom.hlx.page/technologypartners/drafts/dragana/knowledge-overview
- https://mwpw-155065-partner-cards-fallback-for-invalid-thumbnail-images--dx-partners--adobecom.hlx.page/solutionpartners/drafts/dragana/partner-news