### PR TITLE
move config to right place

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,10 +1,10 @@
 {
+  "previewHost": "main--dx-partners--adobecom.aem.page",
+  "liveHost": "main--dx-partners--adobecom.aem.live",
   "plugins": [
     {
       "id": "library",
       "title": "Library",
-      "previewHost": "main--dx-partners--adobecom.aem.page",
-      "liveHost": "main--dx-partners--adobecom.aem.live",
       "environments": [
         "edit"
       ],


### PR DESCRIPTION
hlx configs are migrated by milo team and they are anyway pointing to aem.page/live,this is to have configs aligned
Test url:
https://hlx-config--dx-partners--adobecom.aem.page/