### PR TITLE
MWPW-169131

### DIFF
--- a/eds/scripts/personalizationConfigDX.js
+++ b/eds/scripts/personalizationConfigDX.js
@@ -2,9 +2,13 @@ import { processPrimaryContact, processSalesAccess } from './personalizationUtil
 import {
   getPartnerDataCookieObject,
   hasSalesCenterAccess,
+  isAdminUser,
   isMember,
   partnerIsSignedIn,
   signedInNonMember,
+  isSPPOnly,
+  isTPPOnly,
+  isSPPandTPP,
 } from './utils.js';
 import { PARTNER_LEVEL, PROGRAM } from '../blocks/utils/dxConstants.js';
 
@@ -26,6 +30,10 @@ export const PERSONALIZATION_CONDITIONS = {
   'partner-all-levels': isMember(),
   'partner-sales-access': hasSalesCenterAccess(),
   'partner-level': (level) => PARTNER_LEVEL === level,
+  'partner-spp-member': isSPPOnly(),
+  'partner-tpp-member': isTPPOnly(),
+  'partner-spp-tpp-member': isSPPandTPP(),
+  'partner-admin': isAdminUser(),
 };
 
 export const MAIN_NAV_PERSONALIZATION_CONDITIONS = {

--- a/eds/scripts/utils.js
+++ b/eds/scripts/utils.js
@@ -232,6 +232,11 @@ export function hasSalesCenterAccess() {
   return !!salesCenterAccess;
 }
 
+export function isAdminUser() {
+  const { isAdmin } = getPartnerDataCookieObject(getCurrentProgramType());
+  return !!isAdmin;
+}
+
 export function isRenew() {
   const programType = getCurrentProgramType();
 
@@ -279,6 +284,18 @@ export function partnerIsSignedIn() {
 export function signedInNonMember() {
   return partnerIsSignedIn() && !isMember();
 }
+
+function getProgramTypeStatus() {
+  const isSPP = getPartnerDataCookieValue('spp', 'status') === 'member';
+  const isTPP = getPartnerDataCookieValue('tpp', 'status') === 'member';
+  return { isSPP, isTPP };
+}
+
+const { isSPP, isTPP } = getProgramTypeStatus();
+
+export const isSPPOnly = () => isSPP && !isTPP;
+export const isTPPOnly = () => !isSPP && isTPP;
+export const isSPPandTPP = () => isSPP && isTPP;
 
 export function getNodesByXPath(query, context = document) {
   const nodes = [];


### PR DESCRIPTION
getting user data from cookie

ticket: https://jira.corp.adobe.com/browse/MWPW-169131
Testing url: https://mwpw-169131--dx-partners--adobecom.hlx.page/solutionpartners/drafts/tijana/differentiation/ribbon-on-page

partner-personalization that needs to be authored on page:
'partner-sales-access' for sales center user for notification ribbon/gnav
'partner-spp-member' spp only member
'partner-tpp-member' tpp only memeber
'partner-spp-tpp-member' spp and tpp member
'partner-admin' user has admin rights 

connected to pr on dx-partners-runtime: https://git.corp.adobe.com/wcms/dx-partners-runtime/pull/215