### PR TITLE
MWPW-172860-cover paths that are spp

### DIFF
--- a/eds/scripts/utils.js
+++ b/eds/scripts/utils.js
@@ -109,8 +109,7 @@ function preloadLit(miloLibs) {
 
 export function getProgramType(path) {
   switch (true) {
-    case /\/(solutionpartners|eds|directory|join|self-service-forms\/definition)\//.test(path): return 'spp';
-    case path === '/': return 'spp';
+    case /\/(solutionpartners|eds|directory|join|self-service-forms\/definition)\//.test(path) || /^\/(directory|join|)$/.test(path): return 'spp';
     case /technologypartners/.test(path): return 'tpp';
     case /channelpartners/.test(path): return 'cpp';
     case /channelpartnerassets/.test(path): return 'cpp';

--- a/eds/scripts/utils.js
+++ b/eds/scripts/utils.js
@@ -109,7 +109,8 @@ function preloadLit(miloLibs) {
 
 export function getProgramType(path) {
   switch (true) {
-    case /solutionpartners/.test(path): return 'spp';
+    case /\/(solutionpartners|eds|directory|join|self-service-forms\/definition)\//.test(path): return 'spp';
+    case path === '/': return 'spp';
     case /technologypartners/.test(path): return 'tpp';
     case /channelpartners/.test(path): return 'cpp';
     case /channelpartnerassets/.test(path): return 'cpp';
@@ -118,19 +119,14 @@ export function getProgramType(path) {
 }
 
 export function getProgramHomePage(path) {
-  switch (true) {
-    case /\/(solutionpartners|eds|directory|join|self-service-forms\/definition)\//.test(path):
+  const programType = getProgramType(path);
+  switch (programType) {
+    case 'spp':
       return '/solutionpartners/';
-    case /^\/media[_/]/.test(path):
-      return '/solutionpartners/';
-    case /technologypartners/.test(path):
+    case 'tpp':
       return '/technologypartners/';
-    case /channelpartners/.test(path):
+    case 'cpp':
       return '/channelpartners/';
-    case /channelpartnerassets/.test(path):
-      return '/channelpartners/';
-    case path === '/':
-      return '/solutionpartners/';
     default:
       return '';
   }

--- a/eds/scripts/utils.js
+++ b/eds/scripts/utils.js
@@ -119,7 +119,9 @@ export function getProgramType(path) {
 
 export function getProgramHomePage(path) {
   switch (true) {
-    case /solutionpartners/.test(path):
+    case /\/(solutionpartners|eds|directory|join|self-service-forms\/definition)\//.test(path):
+      return '/solutionpartners/';
+    case /^\/media[_/]/.test(path):
       return '/solutionpartners/';
     case /technologypartners/.test(path):
       return '/technologypartners/';

--- a/eds/scripts/utils.js
+++ b/eds/scripts/utils.js
@@ -129,6 +129,8 @@ export function getProgramHomePage(path) {
       return '/channelpartners/';
     case /channelpartnerassets/.test(path):
       return '/channelpartners/';
+    case path === '/':
+      return '/solutionpartners/';
     default:
       return '';
   }

--- a/test/scripts/utils.jest.js
+++ b/test/scripts/utils.jest.js
@@ -37,7 +37,7 @@ describe('Test utils.js', () => {
     window = Object.create(window);
     Object.defineProperty(window, 'location', {
       value: {
-        pathname: '/solutionpartners',
+        pathname: '/solutionpartners/',
         // eslint-disable-next-line no-return-assign
         assign: (pathname) => window.location.pathname = pathname,
         origin: 'https://partners.stage.adobe.com',


### PR DESCRIPTION
URL for testing:

- https://mwpw-172860-spp-paths--dx-partners--adobecom.aem.page/

since with this pr merged: https://git.corp.adobe.com/wcms/dx-partners-runtime/pull/229 
in case user got 404 under this paths, our code would be triggered and functions isMember() and others that are using it as condition should be aware of new paths

Also, without this, when user is logged in with spp user and go to /join , he will got gnav (instead of logged in gnav), because isMember() is evaluated to false